### PR TITLE
Safari browser bugfix height with "vh" values.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5767,9 +5767,9 @@
       }
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -7128,9 +7128,9 @@
       "dev": true
     },
     "is-reference": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.2.tgz",
-      "integrity": "sha512-Kn5g8c7XHKejFOpTf2QN9YjiHHKl5xRj+2uAZf9iM2//nkBNi/NNeB5JMoun28nEaUVHyPUzqzhfRlfAirEjXg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.3.tgz",
+      "integrity": "sha512-W1iHHv/oyBb2pPxkBxtaewxa1BC58Pn5J0hogyCdefwUIvb6R+TGbAcIa4qPNYLqLhb3EnOgUf2MQkkF76BcKw==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39"
@@ -7962,9 +7962,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash.clonedeep": {
@@ -8498,9 +8498,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -10810,22 +10810,22 @@
       }
     },
     "rollup-plugin-commonjs": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.0.0.tgz",
-      "integrity": "sha512-B8MoX5GRpj3kW4+YaFO/di2JsZkBxNjVmZ9LWjUoTAjq8N9wc7HObMXPsrvolVV9JXVtYSscflXM14A19dXPNQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-10.1.0.tgz",
+      "integrity": "sha512-jlXbjZSQg8EIeAAvepNwhJj++qJWNJw1Cl0YnOqKtP5Djx+fFGkp3WRh+W0ASCaFG5w1jhmzDxgu3SJuVxPF4Q==",
       "dev": true,
       "requires": {
-        "estree-walker": "^0.6.0",
+        "estree-walker": "^0.6.1",
         "is-reference": "^1.1.2",
         "magic-string": "^0.25.2",
-        "resolve": "^1.10.1",
-        "rollup-pluginutils": "^2.7.0"
+        "resolve": "^1.11.0",
+        "rollup-pluginutils": "^2.8.1"
       },
       "dependencies": {
         "resolve": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
-          "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+          "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
           "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
@@ -10843,16 +10843,16 @@
       }
     },
     "rollup-plugin-node-resolve": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.0.0.tgz",
-      "integrity": "sha512-JUFr7DkFps3div9DYwpSg0O+s8zuSSRASUZUVNx6h6zhw2m8vcpToeS68JDPsFbmisMVSMYK0IxftngCRv7M9Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz",
+      "integrity": "sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==",
       "dev": true,
       "requires": {
         "@types/resolve": "0.0.8",
         "builtin-modules": "^3.1.0",
         "is-module": "^1.0.0",
-        "resolve": "^1.10.1",
-        "rollup-pluginutils": "^2.7.0"
+        "resolve": "^1.11.1",
+        "rollup-pluginutils": "^2.8.1"
       },
       "dependencies": {
         "builtin-modules": {
@@ -10862,9 +10862,9 @@
           "dev": true
         },
         "resolve": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
-          "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+          "version": "1.12.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+          "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
           "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
@@ -10883,13 +10883,12 @@
       }
     },
     "rollup-pluginutils": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.7.1.tgz",
-      "integrity": "sha512-3nRf3buQGR9qz/IsSzhZAJyoK663kzseps8itkYHr+Z7ESuaffEPfgRinxbCRA0pf0gzLqkNKkSb8aNVTq75NA==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
       "dev": true,
       "requires": {
-        "estree-walker": "^0.6.0",
-        "micromatch": "^3.1.10"
+        "estree-walker": "^0.6.1"
       }
     },
     "run-async": {
@@ -10947,12 +10946,12 @@
       "dev": true
     },
     "sass": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.20.1.tgz",
-      "integrity": "sha512-BnCawee/L5kVG3B/5Jg6BFwASqUwFVE6fj2lnkVuSXDgQ7gMAhY9a2yPeqsKhJMCN+Wgx0r2mAW7XF/aTF5qtA==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.22.12.tgz",
+      "integrity": "sha512-u5Rxn+dKTPCW5/11kMNxtmqKsxCjcpnqj9CaJoru1NqeJ0DOa9rOM00e0HqmseTAatGkKoLY+jaNecMYevu1gg==",
       "dev": true,
       "requires": {
-        "chokidar": "^2.0.0"
+        "chokidar": ">=2.0.0 <4.0.0"
       }
     },
     "sass-graph": {
@@ -11189,9 +11188,9 @@
       "dev": true
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -12183,14 +12182,14 @@
       }
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
       "optional": true,
       "requires": {
         "block-stream": "*",
-        "fstream": "^1.0.2",
+        "fstream": "^1.0.12",
         "inherits": "2"
       }
     },
@@ -12751,38 +12750,15 @@
       "dev": true
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "unique-filename": {

--- a/src/app/modules/ion-bottom-drawer/ion-bottom-drawer.ts
+++ b/src/app/modules/ion-bottom-drawer/ion-bottom-drawer.ts
@@ -73,7 +73,7 @@ export class IonBottomDrawerComponent implements AfterViewInit, OnChanges {
     this._renderer.setStyle(this._element.nativeElement, 'transition', this.transition);
     switch (state) {
       case DrawerState.Bottom:
-        this._setTranslateY('calc(100vh - ' + this.minimumHeight + 'px)');
+        this._setTranslateY((this._platform.height() - this.minimumHeight) + 'px');
         break;
       case DrawerState.Docked:
         this._setTranslateY((this._platform.height() - this.dockedHeight) + 'px');
@@ -128,7 +128,7 @@ export class IonBottomDrawerComponent implements AfterViewInit, OnChanges {
     if (-ev.deltaY > this._BOUNCE_DELTA) {
       this.state = DrawerState.Docked;
     } else {
-      this._setTranslateY('calc(100vh - ' + this.minimumHeight + 'px)');
+      this._setTranslateY((this._platform.height() - this.minimumHeight) + 'px');
     }
   }
 

--- a/src/app/pages/home/home.ts
+++ b/src/app/pages/home/home.ts
@@ -13,5 +13,5 @@ export class HomePage {
   distanceTop = 56;
   drawerState = DrawerState.Docked;
   states = DrawerState;
-  minimumHeight = 0;
+  minimumHeight = 50;
 }


### PR DESCRIPTION
Hi,

I learn that on mobile Safari browser the value "100vh" seems to be higher than the visible view height. I couldn't see the drawer at bottom state, even if I had 50 has minimum height value.

[Stack overflow source](https://stackoverflow.com/questions/37112218/css3-100vh-not-constant-in-mobile-browser)

If there is a specific use case for "100vh" to get the view height that I missed let me know.