### PR TITLE
Mobile Safari compatibility "100vh" to platform height.

### DIFF
--- a/src/app/modules/ion-bottom-drawer/ion-bottom-drawer.ts
+++ b/src/app/modules/ion-bottom-drawer/ion-bottom-drawer.ts
@@ -73,7 +73,7 @@ export class IonBottomDrawerComponent implements AfterViewInit, OnChanges {
     this._renderer.setStyle(this._element.nativeElement, 'transition', this.transition);
     switch (state) {
       case DrawerState.Bottom:
-        this._setTranslateY('calc(100vh - ' + this.minimumHeight + 'px)');
+        this._setTranslateY((this._platform.height() - this.minimumHeight) + 'px');
         break;
       case DrawerState.Docked:
         this._setTranslateY((this._platform.height() - this.dockedHeight) + 'px');
@@ -128,7 +128,7 @@ export class IonBottomDrawerComponent implements AfterViewInit, OnChanges {
     if (-ev.deltaY > this._BOUNCE_DELTA) {
       this.state = DrawerState.Docked;
     } else {
-      this._setTranslateY('calc(100vh - ' + this.minimumHeight + 'px)');
+      this._setTranslateY((this._platform.height() - this.minimumHeight) + 'px');
     }
   }
 


### PR DESCRIPTION
Hi,

I learn that on mobile Safari browser the value "100vh" seems to be higher than the visible view height. I couldn't see the drawer when it was at the bottom state, even if I had 50 as minimum height value.

Stack overflow source

If there is a specific use case for "100vh" to get the view height that I missed let me know.